### PR TITLE
Update run_EMLassemlyline_for_XX.R

### DIFF
--- a/dataPackages/DataPackageTemplate/run_EMLassemblyline_for_XX.R
+++ b/dataPackages/DataPackageTemplate/run_EMLassemblyline_for_XX.R
@@ -19,6 +19,8 @@
 # 10. Run full script until no errors.
 # 11. Validate the resultant eml file using https://knb.ecoinformatics.org/emlparser/ 
 
+# Note: between different computers and instances of R, the way that 'paths' are treated can change. I you are having trouble loading files using 'params' paths, check what path is being passed to the 'load' function. You may need to add in a leading or trailing '/'
+
 ###### Step 1. Get everything set up. ###### General Setup Stuff
 
 # remotes::install_github("EDIorg/EMLassemblyline" # Only required if not already installed
@@ -28,7 +30,8 @@ pkgList <- c("devtools",
              "EMLassemblyline",
              "lubridate",
              "readtext",
-             "zip"
+             "zip",
+             "miceadds" #use the load.Rdata2 function from this package to load dataset2package into packageDataFrame on line 62, base method 
 )
 
 inst <- pkgList %in% installed.packages()
@@ -39,7 +42,7 @@ if (length(pkgList[!inst]) > 0) {
 
 lapply(pkgList, library, character.only = TRUE, quietly = TRUE)
 
-setwd(params$projectDir)
+setwd(params$projectDir) #may need to manually load /data/temp/reportParameters.Rdata if not already loaded
 
 ###### Step 2. Set Required Parameters #######
 dirName<-"DataPackageTemplate"                                  # Name of the directory where the data packaging scripts are stored. This should just be the directory name (such as "2018_Analysis_PORs"); not the whole path.
@@ -58,7 +61,7 @@ DataPublicationReportURL<-paste0("https://irma.nps.gov/DataStore/Reference/Profi
 publicationYear<-year(Sys.Date())                               # year of data set publication to Data Store.
 datapackageDirectoryName=paste0("dataPackages/",dirName)        # subdirectory where the data package processing files are kept 
 
-packageDataFrame<-load(file=dataset2Package)
+packageDataFrame<-load.Rdata2(filename=dataset2Package)
 
 packageURL<-paste0("https://irma.nps.gov/DataStore/Reference/Profile/",packageRefID)
 


### PR DESCRIPTION
Added line 22 # Note: between different computers and instances of R, the way that 'paths' are treated can change. I you are having trouble loading files using 'params' paths, check what path is being passed to the 'load' function. You may need to add in a leading or trailing '/'

Added package "miceadds" for function load.Rdata2, utilized on line 63 (base "load" was saving chr string into the packageDataFrame object, instead of the data)

Modified line 63 for load.Rdata2

Added comment on line 44 based on trial runs "setwd(params$projectDir) #may need to manually load /data/temp/reportParameters.Rdata if not already loaded"